### PR TITLE
* Remove 'Indicator' selector

### DIFF
--- a/R/run_app.R
+++ b/R/run_app.R
@@ -69,11 +69,10 @@ run_app <- function() {
         nav_insert("tabs", menu_tab)
 
         dataset <- reactive({
-          req(input$indicator)
           req(input$level)
           req(input$weight)
 
-          tilt_profile <- get(input$indicator, "package:tiltWebTool")
+          tilt_profile <- get("emissions", "package:tiltWebTool")
           unnest_level <- get(paste0("unnest_", input$level))
 
           out <- tilt_profile |>

--- a/R/side_bar.R
+++ b/R/side_bar.R
@@ -1,6 +1,5 @@
 side_bar <- function() {
   sidebar(
-    selectChoices("indicator"),
     selectChoices("level"),
     selectChoices("weight", "(product level)"),
     request_data()


### PR DESCRIPTION
* Relates to #127
* Relates to #120

This is temporary so I can focus on the data for now, not on the
interactivity.

I'm hard-wiring the 'emissions' dataset because it has the column
'benchmark' which is a good candidate to split the data by to
create the arrow dataset (although the name of the column in the
real data may be different).



----

TODO

- [ ] Increment version.
- [ ] Update changelog.
- [ ] Link related issue/PR.
- [ ] Review diff.

