### PR TITLE
Update link on climate action guide

### DIFF
--- a/inst/config/link.yml
+++ b/inst/config/link.yml
@@ -14,4 +14,4 @@ default:
 
   climate_action_guide:
     text: "Download the climate action guide"
-    link: "https://github.com/user-attachments/files/16625497/Climate_Action_Questionnaire_tilt_user_platform.xlsx"
+    link: "https://github.com/user-attachments/files/16909035/Climate_Action_Questionnaire_tilt_online_portal.zip"

--- a/man/tiltWebTool-package.Rd
+++ b/man/tiltWebTool-package.Rd
@@ -22,8 +22,9 @@ Useful links:
 
 Authors:
 \itemize{
-  \item Anne Schoenauer \email{anne.schoenauer@2degrees-investing.org}
-  \item Tilman Trompke \email{tilman@2degrees-investing.org}
+  \item Anne Schoenauer \email{anne.schoenauer@2degrees-investing.org} (\href{https://orcid.org/0000-0002-4576-8799}{ORCID})
+  \item Tilman Trompke \email{tilman@2degrees-investing.org} (\href{https://orcid.org/0009-0003-3351-5131}{ORCID})
+  \item Linda Delacombaz \email{linda@2degrees-investing.org}
   \item Kalash Singhal \email{kalash@2degrees-investing.org}
 }
 

--- a/tests/testthat/_snaps/id.md
+++ b/tests/testthat/_snaps/id.md
@@ -52,7 +52,7 @@
     Code
       get_link(guide_id())
     Output
-      <a href="https://github.com/user-attachments/files/16625497/Climate_Action_Questionnaire_tilt_user_platform.xlsx">Download the climate action guide</a>
+      <a href="https://github.com/user-attachments/files/16909035/Climate_Action_Questionnaire_tilt_online_portal.zip">Download the climate action guide</a>
 
 ---
 


### PR DESCRIPTION
The link to climate action guide is updated based on this [comment](https://github.com/2DegreesInvesting/tiltWebTool/issues/196#issuecomment-2334131736).


----

TODO

- [ ] Link related issue/PR.
- [ ] Review diff.

